### PR TITLE
Deserialize nested value objects without __type__ annotations

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -75,12 +75,12 @@ module.exports = class Schema {
       valid = true
     } else if (Array.isArray(value) && Array.isArray(typeDefinition)) {
       valid = value.length === 0 || (
-        typeof typeDefinition[0] === 'function' && value.every(v => v instanceof typeDefinition[0])
+        typeof typeDefinition[0] === 'function' && value.every(v => Schema.objectCanConvertToType(v, typeDefinition[0]))
       ) || (
         typeof typeDefinition[0] === 'string' && value.every(v => typeof v === typeDefinition[0])
       )
     } else if (typeof value === 'object' && typeof typeDefinition === 'function') {
-      valid = value instanceof typeDefinition
+      valid = Schema.objectCanConvertToType(value, typeDefinition)
     } else if (typeDefinition === 'object') {
       valid = typeof expected !== 'undefined'
     } else {
@@ -92,6 +92,22 @@ module.exports = class Schema {
       actual,
       expected,
       propertyName
+    }
+  }
+
+  static objectCanConvertToType(value, typeDefinition) {
+    return value instanceof typeDefinition || Schema.objectCanDeserializeAsType(value, typeDefinition)
+  }
+
+  static objectCanDeserializeAsType(value, typeDefinition) {
+    if (typeof value !== 'object' || !('fromJSON' in typeDefinition)) {
+      return false
+    }
+    try {
+      typeDefinition.fromJSON(value)
+      return true
+    } catch (_) {
+      return false
     }
   }
 

--- a/src/serialization.js
+++ b/src/serialization.js
@@ -19,8 +19,14 @@ module.exports = class Serialization {
     const args = Object.assign({}, raw)
     delete args.__type__
     for (const propertyName in properties) {
-      if (properties[propertyName] == Date && args[propertyName] !== null) {
-        args[propertyName] = new Date(args[propertyName])
+      const arg = args[propertyName]
+      const property = properties[propertyName]
+      if (property == Date && arg !== null) {
+        args[propertyName] = new Date(arg)
+      } else if (typeof property == 'function' && typeof property.fromJSON == 'function') {
+        args[propertyName] = property.fromJSON(arg)
+      } else if (Array.isArray(property) && typeof property[0].fromJSON == 'function') {
+        args[propertyName] = arg.map(element => property[0].fromJSON(element))
       }
     }
     return new ValueObject(args)

--- a/src/serialization.js
+++ b/src/serialization.js
@@ -27,7 +27,9 @@ module.exports = class Serialization {
   }
 
   static serializeValue(value) {
-    return value instanceof Date ? value.toISOString() : value
+    return value instanceof Date
+      ? value.toISOString()
+      : typeof value === "object" && "toJSON" in value ? value.toJSON() : value
   }
 
   static deserializeForNamespaces(namespaces) {

--- a/test/deserializeTest.js
+++ b/test/deserializeTest.js
@@ -75,3 +75,32 @@ describe(ValueObject.deserializeForNamespaces.name, () => {
     })
   })
 })
+
+describe('ValueObject.fromJSON()', () => {
+  it("Creates ValueObject instances from nested values without __type__ annotations", () => {
+    class B extends ValueObject.define({
+      o: 'string'
+    }) {}
+    class A extends ValueObject.define({
+      x: 'string',
+      y: B
+    }) {}
+    const props = { x: '123', y: { o: '2' } }
+    const object = A.fromJSON(props)
+    assert.deepEqual(object, props)
+  })
+
+  it("Creates ValueObject instances from nested values with array properties without __type__ annotations", () => {
+    class B extends ValueObject.define({
+      o: 'string'
+    }) {}
+    class A extends ValueObject.define({
+      x: 'string',
+      y: B,
+      z: [B]
+    }) {}
+    const props = { x: '123', y: { o: '2' }, z: [{ o: '3' }, { o: '4' }] }
+    const object = A.fromJSON(props)
+    assert.deepEqual(object, props)
+  })
+})

--- a/test/deserializeTest.js
+++ b/test/deserializeTest.js
@@ -88,6 +88,8 @@ describe('ValueObject.fromJSON()', () => {
     const props = { x: '123', y: { o: '2' } }
     const object = A.fromJSON(props)
     assert.deepEqual(object, props)
+    assert.equal(object.constructor, A)
+    assert.equal(object.y.constructor, B)
   })
 
   it("Creates ValueObject instances from nested values with array properties without __type__ annotations", () => {
@@ -102,5 +104,9 @@ describe('ValueObject.fromJSON()', () => {
     const props = { x: '123', y: { o: '2' }, z: [{ o: '3' }, { o: '4' }] }
     const object = A.fromJSON(props)
     assert.deepEqual(object, props)
+    assert.equal(object.constructor, A)
+    assert.equal(object.y.constructor, B)
+    assert.equal(object.z[0].constructor, B)
+    assert.equal(object.z[1].constructor, B)
   })
 })

--- a/test/serializeTest.js
+++ b/test/serializeTest.js
@@ -1,0 +1,30 @@
+/* eslint-env mocha */
+"use strict"
+
+const assert = require("assert")
+const ValueObject = require("../valueObject")
+
+describe("ValueObject#toJSON()", () => {
+  it("Is used by JSON.stringify() to create a nested anonymous object with __type__ members", () => {
+    class Bar extends ValueObject.define({ baz: "string" }) {}
+    class Foo extends ValueObject.define({ bar: Bar }) {}
+    const stringified = JSON.stringify(
+      new Foo({ bar: new Bar({ baz: "yeah" }) })
+    )
+    const parsed = JSON.parse(stringified)
+    assert.deepEqual(parsed, {
+      __type__: "Foo",
+      bar: { __type__: "Bar", baz: "yeah" }
+    })
+  })
+
+  it("Creates a nested anonymous object with __type__ members", () => {
+    class Bar extends ValueObject.define({ baz: "string" }) {}
+    class Foo extends ValueObject.define({ bar: Bar }) {}
+    const serialized = new Foo({ bar: new Bar({ baz: "yeah" }) }).toJSON()
+    assert.deepEqual(serialized, {
+      __type__: "Foo",
+      bar: { __type__: "Bar", baz: "yeah" }
+    })
+  })
+})


### PR DESCRIPTION
I might be missing something here because some of this thinking came before my time.

I understand that `JSON.stringify(object)` will call `toJSON()` on each object in the hierarchy (depth first) if it exists. So we use that to add `__type__` annotations when we serialize value objects. These `__type__` are used later in our deserializers to decide which types to treat each part of the serialized ValueObject as.

But we also have a _schema_ when we are deserializing. So in many (or _all_?) cases it should be possible to deserialize a complex value object _without_ type annotations at all. We just grab the property type declared in the schema, and call `fromJSON()` on that type, passing in the serialized object. And we do that recursively.

So this PR relaxes the type checking a little, which means we can do this kind of thing without any pesky `__type__` members:

```javascript
class B extends ValueObject.define({
  o: 'string'
}) {}
class A extends ValueObject.define({
  x: 'string',
  y: B,
  z: [B]
}) {}
const props = { x: '123', y: { o: '2' }, z: [{ o: '3' }, { o: '4' }] }
const object = A.fromJSON(props)
assert.deepEqual(object, props)
```