### PR TITLE
Invalid Date detection

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -60,6 +60,8 @@ module.exports = class Schema {
       } else {
         actual = `array of multiple types`
       }
+    } else if (value instanceof Date && !isFinite(value)) {
+      actual = 'Date (Invalid Date)'
     } else if (typeof value === 'object') {
       if (value === null) {
         actual = null
@@ -79,6 +81,8 @@ module.exports = class Schema {
       ) || (
         typeof typeDefinition[0] === 'string' && value.every(v => typeof v === typeDefinition[0])
       )
+    } else if (value instanceof Date && !isFinite(value)) {
+      valid = false
     } else if (typeof value === 'object' && typeof typeDefinition === 'function') {
       valid = value instanceof typeDefinition
     } else if (typeDefinition === 'object') {

--- a/test/valueObjectTest.js
+++ b/test/valueObjectTest.js
@@ -88,6 +88,16 @@ describe(ValueObject.name, () => {
     )
   })
 
+  it('does not allow invalid dates', () => {
+    class Foo extends ValueObject.define({ date: Date }) {}
+    const date = new Date('2014-25-23') // Invalid date
+
+    assertThrows(
+      () => new Foo({ date }),
+      'Foo({date:instanceof Date}) called with invalid types {date:Date (Invalid Date)} - "date" is invalid'
+    )
+  })
+
   it('does not allow calling define on ValueObject subclasses', () => {
     class MyValueObject extends ValueObject {}
     assertThrows(


### PR DESCRIPTION
It's possible to construct invalid `Date` objects in JavaScript. For example `new Date('2014-25-23')`. They lurk around and don't let you know they're invalid until you try to call a method on them, like `#toISOString()`, at which point they throw an exception.

This change detects invalid dates a little earlier (when a value object is instantiated), which might help catch nasty bugs.

To catch invalid dates even earlier (before they're passed to a value object), try this instead of `new Date(s)` and `Date.parse(s)` in your own codebases:

```javascript
function newDate(s) {
  const d = new Date(s)
  if (!isFinite(d)) throw new Error(`Invalid Date: ${s}`)
  return d
}

function parseDate(s) {
  const d = Date.parse(s)
  if (!isFinite(d)) throw new Error(`Invalid Date: ${s}`)
  return d
}
```
