### PR TITLE
Firefox compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "npm run eslint && npm run coverage",
     "eslint": "eslint src test",
     "mocha": "mocha",
+    "karma": "karma start --browsers Firefox,Chrome --single-run",
     "coverage": "node --harmony ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- test"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "karma-babel-preprocessor": "^8.0.0-beta.0",
     "karma-browserify": "^5.2.0",
     "karma-chrome-launcher": "^2.2.0",
+    "karma-firefox-launcher": "^1.1.0",
     "karma-ie-launcher": "^1.0.0",
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",

--- a/test/assertThrows.js
+++ b/test/assertThrows.js
@@ -8,7 +8,11 @@ function assertThrows(fn, message, expose = () => {}) {
     throw new Error('Should have thrown an error')
   } catch (err) {
     assert(typeof err !== 'undefined', 'threw undefined!')
-    assert.equal(err.message, message)
+    if (message instanceof RegExp) {
+      assert(err.message.match(message))
+    } else {
+      assert.equal(err.message, message)
+    }
     expose(err)
   }
 }

--- a/test/valueObjectTest.js
+++ b/test/valueObjectTest.js
@@ -583,7 +583,7 @@ describe('ValueObject', () => {
 
       assertThrows(
         () => foo.dingbat = 'badger',
-        "Cannot add property dingbat, object is not extensible"
+        /is not extensible/
       )
     })
 
@@ -593,7 +593,7 @@ describe('ValueObject', () => {
 
       assertThrows(
         () => foo.ok = 'badger',
-        "Cannot assign to read only property 'ok' of object '#<Foo>'"
+        /read.only/
       )
     })
 
@@ -1108,7 +1108,7 @@ describe('ValueObject', () => {
         const foo = new Foo({ x: 'hello' })
         assertThrows(
           () => { foo.z = 'yeah' },
-          'Cannot add property z, object is not extensible'
+          /not extensible/
         )
       } finally {
         ValueObject.enableFreeze()

--- a/value-object.js
+++ b/value-object.js
@@ -487,7 +487,9 @@ InvalidProperty.prototype.describe = function () {
 }
 
 function ValidationError(object, failures) {
-  Error.captureStackTrace(this, ValidationError)
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, ValidationError)
+  }
   this.object = object
   this.failures = failures
   this.message = functionName(object.constructor) + ' is invalid: ' + failures.describe()


### PR DESCRIPTION
A few tweaks for firefox compatibility:

* Errors have slightly different messages
* Firefox doesn't support `Error.captureStackTrace`

Adds a `yarn karma` command to run the tests in karma against chrome and firefox.