### PR TITLE
toPlainObject when nested object is null should serialise correctly

### DIFF
--- a/test/valueObjectTest.js
+++ b/test/valueObjectTest.js
@@ -933,6 +933,13 @@ describe('ValueObject', () => {
       assert.equal(JSON.stringify(y.toPlainObject()), '{"b":null}')
     })
 
+    it('converts null values of inline nested objects', () => {
+      class X extends ValueObject.define({ a: 'string', b: { c: 'string'} }) {}
+      const x = new X({ a: 'asd', b: null })
+
+      assert.equal(JSON.stringify(x.toPlainObject()), '{"a":"asd","b":null}')
+    })
+
     it('converts constructor properties', () => {
       function X() { this.z = 'hi' }
       class Y extends ValueObject.define({ x: X }) {}

--- a/value-object.js
+++ b/value-object.js
@@ -248,8 +248,13 @@ Schema.prototype.toPlainObject = function(instance) {
   var object = {}
   for (var propertyName in this.propertyTypes) {
     var property = this.propertyTypes[propertyName]
-    object[propertyName] = typeof property.toPlainObject === 'function' ?
-      property.toPlainObject(instance[propertyName]) : JSON.parse(JSON.stringify(instance[propertyName]))
+
+    if(instance[propertyName]) {
+      object[propertyName] = typeof property.toPlainObject === 'function' ?
+        property.toPlainObject(instance[propertyName]) : JSON.parse(JSON.stringify(instance[propertyName]))
+    } else {
+      object[propertyName] = null
+    }
   }
   return object
 }


### PR DESCRIPTION
toPlainObject fails when serialising a value object containing a nested object, whose value is null.

I think we should check for null values and serialise them correctly