### PR TITLE
Multi-line error messages

### DIFF
--- a/test/valueObjectTest.js
+++ b/test/valueObjectTest.js
@@ -83,7 +83,11 @@ describe('ValueObject', () => {
 
       assertThrows(
         () => new Foo({ a: 'yep', b: undefined }),
-        'Foo({a:string, b:string}) called with invalid types {a:string, b:undefined} - "b" is invalid (Expected string, was undefined)',
+        'Foo was constructed with invalid property values\n' +
+          '  Expected: { a:string, b:string }\n' +
+          '  Actual:   { a:string, b:undefined }\n' +
+          '  b is invalid:\n' +
+          '    Expected string, was undefined',
         error => assert(error instanceof ValueObject.ValueObjectError)
       )
     })
@@ -95,15 +99,23 @@ describe('ValueObject', () => {
 
       assertThrows(
         () => new Foo({ bar: new Bar({ baz: undefined }) }),
-        'Bar({baz:Baz}) called with invalid types {baz:undefined} - "baz" is invalid (Expected Baz, was undefined)',
+        'Bar was constructed with invalid property values\n' +
+          '  Expected: { baz:Baz }\n' +
+          '  Actual:   { baz:undefined }\n' +
+          '  baz is invalid:\n' +
+          '    Expected Baz, was undefined',
         error => assert(error instanceof ValueObject.ValueObjectError)
       )
     })
 
     it('fails when instantiated with zero arguments', () => {
       class Foo extends ValueObject.define({ b: 'string', a: ['string'] }) {}
-      assertThrows(() => new Foo(), 'Foo({b:string, a:[string]}) called with 0 arguments', error =>
-        assert(error instanceof ValueObject.ValueObjectError)
+      assertThrows(
+        () => new Foo(),
+        'Foo was constructed with invalid property values\n' +
+          '  Expected: { b:string, a:[string] }\n' +
+          '  Actual:   { 0 arguments }',
+        error => assert(error instanceof ValueObject.ValueObjectError)
       )
     })
 
@@ -111,7 +123,9 @@ describe('ValueObject', () => {
       class Foo extends ValueObject.define({ b: 'string', a: 'string' }) {}
       assertThrows(
         () => new Foo({ a: 'ok' }, null),
-        'Foo({b:string, a:string}) called with 2 arguments',
+        'Foo was constructed with invalid property values\n' +
+          '  Expected: { b:string, a:string }\n' +
+          '  Actual:   { 2 arguments }',
         error => assert(error instanceof ValueObject.ValueObjectError)
       )
     })
@@ -123,7 +137,11 @@ describe('ValueObject', () => {
       const d = 'D'
       assertThrows(
         () => new WantsThreeProps({ a, d, b }),
-        'WantsThreeProps({c:string, a:string, b:string}) called with {a, d, b} ("c" is missing, "d" is unexpected)',
+        'WantsThreeProps was constructed with invalid property values\n' +
+          '  Expected: { c:string, a:string, b:string }\n' +
+          '  Actual:   { a:string, b:string, d:string }\n' +
+          '  c is missing\n' +
+          '  d is unexpected',
         error => assert(error instanceof ValueObject.ValueObjectError)
       )
     })
@@ -132,8 +150,14 @@ describe('ValueObject', () => {
       class WantsNestedProps extends ValueObject.define({ x: { y: 'string' } }) {}
       assertThrows(
         () => new WantsNestedProps({ x: {} }),
-        'WantsNestedProps({x:{y:string}}) called with invalid types {x:object} - ' +
-          '"x" is invalid (Struct({y:string}) called with {} ("y" is missing))',
+        'WantsNestedProps was constructed with invalid property values\n' +
+          '  Expected: { x:{y:string} }\n' +
+          '  Actual:   { x:object }\n' +
+          '  x is invalid:\n' +
+          '    Struct was constructed with invalid property values\n' +
+          '      Expected: { y:string }\n' +
+          '      Actual:   {  }\n' +
+          '      y is missing',
         error => assert(error instanceof ValueObject.ValueObjectError)
       )
     })
@@ -142,8 +166,14 @@ describe('ValueObject', () => {
       class WantsNestedProps extends ValueObject.define({ x: { y: 'string' } }) {}
       assertThrows(
         () => new WantsNestedProps({ x: 'zomg' }),
-        'WantsNestedProps({x:{y:string}}) called with invalid types {x:string} - ' +
-          '"x" is invalid (Struct({y:string}) called with string (expected object))',
+        'WantsNestedProps was constructed with invalid property values\n' +
+          '  Expected: { x:{y:string} }\n' +
+          '  Actual:   { x:string }\n' +
+          '  x is invalid:\n' +
+          '    Struct was constructed with invalid property values\n' +
+          '      Expected: { y:string }\n' +
+          '      Actual:   { <string value> }\n' +
+          '      expected object with property values',
         error => assert(error instanceof ValueObject.ValueObjectError)
       )
     })
@@ -153,7 +183,11 @@ describe('ValueObject', () => {
       const a = 'A'
       assertThrows(
         () => new WantsOneProp({ a, b: '1', c: '2' }),
-        'WantsOneProp({a:string}) called with {a, b, c} ("b" is unexpected, "c" is unexpected)',
+        'WantsOneProp was constructed with invalid property values\n' +
+          '  Expected: { a:string }\n' +
+          '  Actual:   { a:string, b:string, c:string }\n' +
+          '  b is unexpected\n' +
+          '  c is unexpected',
         error => assert(error instanceof ValueObject.ValueObjectError)
       )
     })
@@ -164,7 +198,11 @@ describe('ValueObject', () => {
 
       assertThrows(
         () => new Foo({ date }),
-        'Foo({date:Date}) called with invalid types {date:Date} - "date" is invalid (Invalid Date)',
+        'Foo was constructed with invalid property values\n' +
+          '  Expected: { date:Date }\n' +
+          '  Actual:   { date:Date }\n' +
+          '  date is invalid:\n' +
+          '    Invalid Date',
         error => assert(error instanceof ValueObject.ValueObjectError)
       )
     })
@@ -175,7 +213,11 @@ describe('ValueObject', () => {
 
       assertThrows(
         () => new Foo({ date }),
-        'Foo({date:Date}) called with invalid types {date:object} - "date" is invalid (Expected Date, string or number, was object)',
+        'Foo was constructed with invalid property values\n' +
+          '  Expected: { date:Date }\n' +
+          '  Actual:   { date:object }\n' +
+          '  date is invalid:\n' +
+          '    Expected Date, string or number, was object',
         error => assert(error instanceof ValueObject.ValueObjectError)
       )
     })
@@ -263,8 +305,13 @@ describe('ValueObject', () => {
       const b = 3
       assertThrows(
         () => new Foo({ b, a }),
-        'Foo({a:number, b:string}) called with invalid types {a:string, b:number} - ' +
-          '"a" is invalid (Expected number, was string), "b" is invalid (Expected string, was number)',
+        'Foo was constructed with invalid property values\n' +
+          '  Expected: { a:number, b:string }\n' +
+          '  Actual:   { a:string, b:number }\n' +
+          '  a is invalid:\n' +
+          '    Expected number, was string\n' +
+          '  b is invalid:\n' +
+          '    Expected string, was number',
         error => assert(error instanceof ValueObject.ValueObjectError)
       )
     })
@@ -274,7 +321,11 @@ describe('ValueObject', () => {
 
       assertThrows(
         () => new Foo({ a: new Date() }),
-        'Foo({a:Array}) called with invalid types {a:Date} - "a" is invalid (Expected array, was Date)',
+        'Foo was constructed with invalid property values\n' +
+          '  Expected: { a:Array }\n' +
+          '  Actual:   { a:Date }\n' +
+          '  a is invalid:\n' +
+          '    Expected array, was Date',
         error => assert(error instanceof ValueObject.ValueObjectError)
       )
     })
@@ -306,9 +357,11 @@ describe('ValueObject', () => {
       const e = null
       assertThrows(
         () => new Foo({ b, a, c, d, e }),
-        'Foo({a:string, b:Child, c:string, d:boolean, e:any}) ' +
-          'called with invalid types {a:string, b:WrongChild, c:null, d:boolean, e:null} - ' +
-          '"b" is invalid (Expected Child, was WrongChild)',
+        'Foo was constructed with invalid property values\n' +
+          '  Expected: { a:string, b:Child, c:string, d:boolean, e:any }\n' +
+          '  Actual:   { a:string, b:WrongChild, c:null, d:boolean, e:null }\n' +
+          '  b is invalid:\n' +
+          '    Expected Child, was WrongChild',
         error => assert(error instanceof ValueObject.ValueObjectError)
       )
     })
@@ -321,11 +374,18 @@ describe('ValueObject', () => {
       class Foo extends ValueObject.define({ a: 'string', b: X, c: ['number'] }) {}
       assertThrows(
         () => new Foo({ a, b, c }),
-        'Foo({a:string, b:X, c:[number]}) ' +
-          'called with invalid types {a:number, b:Date, c:Array} - ' +
-          '"a" is invalid (Expected string, was number), ' +
-          '"b" is invalid (Expected X, was Date), ' +
-          '"c" is invalid ([1] is invalid (Expected number, was undefined), [2] is invalid (Expected number, was undefined))',
+        'Foo was constructed with invalid property values\n' +
+          '  Expected: { a:string, b:X, c:[number] }\n' +
+          '  Actual:   { a:number, b:Date, c:Array }\n' +
+          '  a is invalid:\n' +
+          '    Expected string, was number\n' +
+          '  b is invalid:\n' +
+          '    Expected X, was Date\n' +
+          '  c is invalid:\n' +
+          '    [1] is invalid:\n' +
+          '      Expected number, was undefined\n' +
+          '    [2] is invalid:\n' +
+          '      Expected number, was undefined',
         error => assert(error instanceof ValueObject.ValueObjectError)
       )
     })
@@ -637,7 +697,10 @@ describe('ValueObject', () => {
       new Sub({ id: 'xyz', seq: 4, city: 'London', owner: 'Aslak' })
       assertThrows(
         () => new Sub({ seq: 4, city: 'London', owner: 'Aslak' }),
-        'Sub({id:string, seq:number, city:string, owner:string}) called with {seq, city, owner} ("id" is missing)',
+        'Sub was constructed with invalid property values\n' +
+          '  Expected: { id:string, seq:number, city:string, owner:string }\n' +
+          '  Actual:   { seq:number, city:string, owner:string }\n' +
+          '  id is missing',
         error => assert(error instanceof ValueObject.ValueObjectError)
       )
     })
@@ -764,8 +827,11 @@ describe('ValueObject', () => {
       class Foo extends ValueObject.define({ things: ['string'] }) {}
       assertThrows(
         () => new Foo({ things: 666 }),
-        'Foo({things:[string]}) called with invalid types {things:number} - ' +
-          '"things" is invalid (Expected array, was number)',
+        'Foo was constructed with invalid property values\n' +
+          '  Expected: { things:[string] }\n' +
+          '  Actual:   { things:number }\n' +
+          '  things is invalid:\n' +
+          '    Expected array, was number',
         error => assert(error instanceof ValueObject.ValueObjectError)
       )
     })
@@ -1060,7 +1126,11 @@ describe('ValueObject', () => {
       class Hello extends ValueObject.define({ x: 'string' }) {}
       assertThrows(
         () => new Hello({ x: 'yo' }).with({ y: 'ok', z: 'good' }),
-        'Hello({x:string}) called with {x, y, z} ("y" is unexpected, "z" is unexpected)'
+        'Hello was constructed with invalid property values\n' +
+          '  Expected: { x:string }\n' +
+          '  Actual:   { x:string, y:string, z:string }\n' +
+          '  y is unexpected\n' +
+          '  z is unexpected'
       )
     })
 
@@ -1094,11 +1164,18 @@ describe('ValueObject', () => {
       const foo = new Foo({ a: 'ok', b: new X(), c: [1, 2, 3] })
       assertThrows(
         () => foo.with({ a, b, c }),
-        'Foo({a:string, b:X, c:[number]}) ' +
-          'called with invalid types {a:number, b:Date, c:Array} - ' +
-          '"a" is invalid (Expected string, was number), ' +
-          '"b" is invalid (Expected X, was Date), ' +
-          '"c" is invalid ([1] is invalid (Expected number, was undefined), [2] is invalid (Expected number, was undefined))',
+        'Foo was constructed with invalid property values\n' +
+          '  Expected: { a:string, b:X, c:[number] }\n' +
+          '  Actual:   { a:number, b:Date, c:Array }\n' +
+          '  a is invalid:\n' +
+          '    Expected string, was number\n' +
+          '  b is invalid:\n' +
+          '    Expected X, was Date\n' +
+          '  c is invalid:\n' +
+          '    [1] is invalid:\n' +
+          '      Expected number, was undefined\n' +
+          '    [2] is invalid:\n' +
+          '      Expected number, was undefined',
         error => assert(error instanceof ValueObject.ValueObjectError)
       )
     })

--- a/test/valueObjectTest.js
+++ b/test/valueObjectTest.js
@@ -192,6 +192,19 @@ describe('ValueObject', () => {
       )
     })
 
+    it('fails when instantiated with constructor properties whose constructors throw', () => {
+      const constructorError = new Error('oh noes')
+      class Bad extends ValueObject.define({ x: 'string' }) {
+        constructor() {
+          throw constructorError
+        }
+      }
+      class HasBadProps extends ValueObject.define({ a: Bad, b: Bad }) {}
+      assertThrows(() => new HasBadProps({ a: {}, b: {} }), constructorError.message, error =>
+        assert.equal(error, constructorError)
+      )
+    })
+
     it('does not allow invalid dates', () => {
       class Foo extends ValueObject.define({ date: Date }) {}
       const date = new Date('2014-25-23') // Invalid date

--- a/test/valueObjectTest.js
+++ b/test/valueObjectTest.js
@@ -317,15 +317,15 @@ describe('ValueObject', () => {
       class X {}
       const a = 666
       const b = new Date()
-      const c = -1
-      class Foo extends ValueObject.define({ a: 'string', b: X, c: 'object' }) {}
+      const c = [1, undefined, undefined]
+      class Foo extends ValueObject.define({ a: 'string', b: X, c: ['number'] }) {}
       assertThrows(
         () => new Foo({ a, b, c }),
-        'Foo({a:string, b:X, c:object}) ' +
-          'called with invalid types {a:number, b:Date, c:number} - ' +
+        'Foo({a:string, b:X, c:[number]}) ' +
+          'called with invalid types {a:number, b:Date, c:Array} - ' +
           '"a" is invalid (Expected string, was number), ' +
           '"b" is invalid (Expected X, was Date), ' +
-          '"c" is invalid (Expected object, was number)',
+          '"c" is invalid ([1] is invalid (Expected number, was undefined), [2] is invalid (Expected number, was undefined))',
         error => assert(error instanceof ValueObject.ValueObjectError)
       )
     })

--- a/test/valueObjectTest.js
+++ b/test/valueObjectTest.js
@@ -1084,6 +1084,24 @@ describe('ValueObject', () => {
       Super.prototype.zz = 'whatevs'
       new Yo({ x: '1' }).with(new Super())
     })
+
+    it('fails when called with multiple invalid types with error explaining which properties', () => {
+      class X {}
+      const a = 666
+      const b = new Date()
+      const c = [1, undefined, undefined]
+      class Foo extends ValueObject.define({ a: 'string', b: X, c: ['number'] }) {}
+      const foo = new Foo({ a: 'ok', b: new X(), c: [1, 2, 3] })
+      assertThrows(
+        () => foo.with({ a, b, c }),
+        'Foo({a:string, b:X, c:[number]}) ' +
+          'called with invalid types {a:number, b:Date, c:Array} - ' +
+          '"a" is invalid (Expected string, was number), ' +
+          '"b" is invalid (Expected X, was Date), ' +
+          '"c" is invalid ([1] is invalid (Expected number, was undefined), [2] is invalid (Expected number, was undefined))',
+        error => assert(error instanceof ValueObject.ValueObjectError)
+      )
+    })
   })
 
   describe('#validate()', () => {

--- a/test/valueObjectTest.js
+++ b/test/valueObjectTest.js
@@ -700,7 +700,7 @@ describe('ValueObject', () => {
       ValueObject.definePropertyType('money', {
         coerce(value) {
           const parts = value.split(' ')
-          return { amount: Number(parts[0]), currency: parts[1] }
+          return { value: { amount: Number(parts[0]), currency: parts[1] } }
         },
 
         areEqual(a, b) {

--- a/value-object.js
+++ b/value-object.js
@@ -456,22 +456,18 @@ ConstructorProp.prototype.toPlainObject = function(instance) {
 function DateProp() {}
 DateProp.prototype.coerce = function(value) {
   if (value === null) return { value: null }
-  try {
-    var date
-    if (value instanceof Date) {
-      date = value
-    } else if (typeof value === 'string' || typeof value === 'number') {
-      date = new Date(value)
-    } else {
-      return { failureMessage: 'Expected Date, string or number, was ' + inspectType(value) }
-    }
-    if (!isFinite(date)) {
-      return { failureMessage: 'Invalid Date' }
-    }
-    return { value: date }
-  } catch (e) {
-    return { failureMessage: e.message }
+  var date
+  if (value instanceof Date) {
+    date = value
+  } else if (typeof value === 'string' || typeof value === 'number') {
+    date = new Date(value)
+  } else {
+    return { failureMessage: 'Expected Date, string or number, was ' + inspectType(value) }
   }
+  if (!isFinite(date)) {
+    return { failureMessage: 'Invalid Date' }
+  }
+  return { value: date }
 }
 DateProp.prototype.areEqual = function(a, b) {
   return a.getTime() == b.getTime()

--- a/value-object.js
+++ b/value-object.js
@@ -71,7 +71,7 @@ ValueObject.prototype.with = function(newPropertyValues) {
       }
       var coercionResult = property.coerce(newPropertyValues[newPropertyName])
       if (coercionResult.failureMessage) {
-        throw new ValueObjectError(coercionResult.failureMessage)
+        Constructor.schema.assignProperties(instance, [extend(this, newPropertyValues)])
       } else {
         instance[newPropertyName] = coercionResult.value
       }
@@ -416,21 +416,17 @@ function ConstructorProp(ctor) {
 ConstructorProp.prototype.coerce = function(value) {
   if (value === null) return { value: null }
   var Constructor = this.ctor
-  try {
-    if (!(value instanceof Constructor)) {
-      if (typeof Constructor.fromJSON === 'function') {
-        var properties = Constructor.fromJSON(value)
-        return { value: new Constructor(properties) }
-      }
-      if (value && value.constructor === Object) {
-        return { value: new Constructor(value) }
-      }
-      return {
-        failureMessage: 'Expected ' + functionName(Constructor) + ', was ' + inspectType(value)
-      }
+  if (!(value instanceof Constructor)) {
+    if (typeof Constructor.fromJSON === 'function') {
+      var properties = Constructor.fromJSON(value)
+      return { value: new Constructor(properties) }
     }
-  } catch (e) {
-    return { failureMessage: e.message }
+    if (value && value.constructor === Object) {
+      return { value: new Constructor(value) }
+    }
+    return {
+      failureMessage: 'Expected ' + functionName(Constructor) + ', was ' + inspectType(value)
+    }
   }
   return { value: value }
 }

--- a/value-object.js
+++ b/value-object.js
@@ -258,10 +258,7 @@ Schema.prototype.coerce = function(value) {
   try {
     return { value: new Constructor(value) }
   } catch (e) {
-    if (e.coercionFailures) {
-      return { failureMessage: e.coercionFailures }
-    }
-    return { failureMessage: e.message }
+    return { failureMessage: e.coercionFailures }
   }
 }
 Schema.prototype.areEqual = function(a, b) {

--- a/value-object.js
+++ b/value-object.js
@@ -196,7 +196,7 @@ Schema.prototype.assignProperties = function(assignee, args) {
     if (coercionResult.failureMessage) {
       failures.push({
         propertyName: propertyName,
-        error: new ValueObjectError(coercionResult.failureMessage)
+        failureMessage: coercionResult.failureMessage
       })
     } else {
       assignee[propertyName] = coercionResult.value
@@ -212,7 +212,7 @@ Schema.prototype.assignProperties = function(assignee, args) {
         '} - ' +
         failures
           .map(function(failure) {
-            return '"' + failure.propertyName + '" is invalid (' + failure.error.message + ')'
+            return '"' + failure.propertyName + '" is invalid (' + failure.failureMessage + ')'
           })
           .join(', ')
     )

--- a/value-object.js
+++ b/value-object.js
@@ -320,15 +320,22 @@ ArrayProp.prototype.coerce = function(value) {
     return { failureMessage: 'Expected array, was ' + inspectType(value) }
   }
   var elementType = this.elementType
-  try {
-    return {
-      value: value.map(function(element) {
-        return elementType.coerce(element).value
-      })
+  var failures = []
+  var convertedValues = []
+  for (var i = 0; i < value.length; i++) {
+    var coercionResult = elementType.coerce(value[i])
+    if (coercionResult.failureMessage) {
+      failures.push('[' + i + '] is invalid (' + coercionResult.failureMessage + ')')
+    } else {
+      convertedValues.push(coercionResult.value)
     }
-  } catch (e) {
-    return { failureMessage: e.message }
   }
+  if (failures.length > 0) {
+    return {
+      failureMessage: failures.join(', ')
+    }
+  }
+  return { value: convertedValues }
 }
 ArrayProp.prototype.areEqual = function(a, b) {
   if (a.length != b.length) return false


### PR DESCRIPTION
Given a complex value object like this one:

```js
class Foo extends ValueObject.define({ x: { y: 'string' } }) {}
```

...attempts to instantiate `Foo` with invalid arguments like this:

```js
new Foo({ x: {} })
```

...throws an error like this:

```
Foo({x:{y:string}}) called with invalid types {x:string} - "x" is invalid (Struct({y:string}) called with {} ("y" is missing))
```

...which is fairly easy to understand in this small example, but can be very hard to follow when there are more and deeper properties.

This changes all "invalid properties" error message so they are easier to digest, like:

```
Foo was constructed with invalid property values
  Expected: { x:{y:string} }
  Actual:   { x:object }
  x is invalid:
    Struct was constructed with invalid property values
      Expected: { y:string }
      Actual:   {  }
      y is missing
```