### PR TITLE
Call the original constructor in .with(...)

### DIFF
--- a/test/valueObjectTest.js
+++ b/test/valueObjectTest.js
@@ -1153,6 +1153,16 @@ describe('ValueObject', () => {
       assert.equal(yo.constructor, Yo)
     })
 
+    it('calls the original constructor', () => {
+      class X extends ValueObject.define({ a: 'string' }) {
+        constructor({ a }) {
+          super({ a: a + '!' })
+        }
+      }
+      const x = new X({ a: 'G' }).with({ a: 'H' })
+      assert.equal(x.a, 'H!')
+    })
+
     it('returns instances with schemas', () => {
       class Yo extends ValueObject.define({ x: 'string' }) {}
       const yo = new Yo({ x: '1' }).with({ x: '2' })

--- a/value-object.js
+++ b/value-object.js
@@ -56,35 +56,7 @@ ValueObject.prototype.isEqualTo = function(other) {
 }
 ValueObject.prototype.with = function(newPropertyValues) {
   var Constructor = this.constructor
-  if (!Constructor.With) {
-    Constructor.With = function With() {}
-    Constructor.With.prototype = Object.create(Constructor.prototype)
-    Constructor.With.prototype.constructor = Constructor
-  }
-
-  var instance = new Constructor.With()
-  for (var propertyName in Constructor.schema.propertyTypes) {
-    instance[propertyName] = this[propertyName]
-  }
-  for (var newPropertyName in newPropertyValues) {
-    if (Object.prototype.hasOwnProperty.call(newPropertyValues, newPropertyName)) {
-      var property = Constructor.schema.propertyTypes[newPropertyName]
-      if (!property) {
-        new Constructor(extend(this, newPropertyValues))
-      }
-      var coercionResult = property.coerce(newPropertyValues[newPropertyName])
-      if (coercionResult.failure) {
-        new Constructor(extend(this, newPropertyValues))
-      } else {
-        instance[newPropertyName] = coercionResult.value
-      }
-    }
-  }
-  if (typeof instance._init === 'function') {
-    instance._init()
-  }
-  freeze(instance)
-  return instance
+  return new Constructor(extend(this.toPlainObject(), newPropertyValues))
 }
 ValueObject.prototype.toJSON = function() {
   return this.constructor.schema.toJSON(this)

--- a/value-object.js
+++ b/value-object.js
@@ -581,19 +581,22 @@ function arrayIsMissing(array) {
 }
 
 function extend(extendee, extender) {
-  var extended = {},
-    prop
-  for (prop in extendee) {
-    if (Object.prototype.hasOwnProperty.call(extendee, prop)) {
-      extended[prop] = extendee[prop]
-    }
-  }
-  for (prop in extender) {
-    if (Object.prototype.hasOwnProperty.call(extender, prop)) {
-      extended[prop] = extender[prop]
-    }
-  }
+  var extended = {}
+  withOwnProperties(extendee, function(prop) {
+    extended[prop] = extendee[prop]
+  })
+  withOwnProperties(extender, function(prop) {
+    extended[prop] = extender[prop]
+  })
   return extended
+}
+
+function withOwnProperties(subject, fn) {
+  for (var prop in subject) {
+    if (Object.prototype.hasOwnProperty.call(subject, prop)) {
+      fn(prop)
+    }
+  }
 }
 
 function inspectType(o) {


### PR DESCRIPTION
When calling `.with()` on a ValueObject instance, we avoid calling the original constructor, and instead we return an object with a different constructor. Although this is good for performance, there are a couple of issues:

1. The original constructor is never called, which may do additional processing before calling `super(...args)` to assign properties.
2. The returned ValueObject instance does not have the same `constructor` value as the original instance.

Both of these may lead to subtle bugs, so it's better to be safe than performant.