### PR TITLE
Make .with() not use .toPlainObject()

### DIFF
--- a/test/valueObjectTest.js
+++ b/test/valueObjectTest.js
@@ -1219,6 +1219,22 @@ describe('ValueObject', () => {
         error => assert(error instanceof ValueObject.ValueObjectError)
       )
     })
+
+    it('does not use .toPlainObject()', () => {
+      class Money extends ValueObject.define({ amount: 'number', currency: 'string' }) {
+        toPlainObject() {
+          throw new Error('.with() should not use .toPlainObject()')
+        }
+      }
+
+      const money = new Money({ amount: 100, currency: 'ZAR' })
+      const newMoney = money.with({ amount: 200 })
+
+      assert.deepEqual(newMoney, {
+        amount: 200,
+        currency: 'ZAR'
+      })
+    })
   })
 
   describe('#validate()', () => {

--- a/value-object.js
+++ b/value-object.js
@@ -56,7 +56,16 @@ ValueObject.prototype.isEqualTo = function(other) {
 }
 ValueObject.prototype.with = function(newPropertyValues) {
   var Constructor = this.constructor
-  return new Constructor(extend(this.toPlainObject(), newPropertyValues))
+  var finalPropertyValues = {}
+  var thisPropertyNames = Constructor.schema.propertyNames
+  for (var i = 0; i < thisPropertyNames.length; i++) {
+    finalPropertyValues[thisPropertyNames[i]] = this[thisPropertyNames[i]]
+  }
+  var newPropertyNames = ownKeys(newPropertyValues)
+  for (var j = 0; j < newPropertyNames.length; j++) {
+    finalPropertyValues[newPropertyNames[j]] = newPropertyValues[newPropertyNames[j]]
+  }
+  return new Constructor(finalPropertyValues)
 }
 ValueObject.prototype.toJSON = function() {
   return this.constructor.schema.toJSON(this)
@@ -557,6 +566,16 @@ function keys(o) {
   var k = []
   for (var key in o) {
     k.push(key)
+  }
+  return k
+}
+
+function ownKeys(o) {
+  var k = []
+  for (var key in o) {
+    if (Object.prototype.hasOwnProperty.call(o, key)) {
+      k.push(key)
+    }
   }
   return k
 }


### PR DESCRIPTION
`ValueObject.prototype.toPlainObject()` can be overridden in subclasses, e.g. for value objects that can be serialized as strings. But we use also `.toPlainObject()` in `.with()`, which means e.g. string values cannot be extended.

This change makes `.with()` enumerate properties instead of depending on `.toPlainObject()`

