### PR TITLE
Property metadata

### DIFF
--- a/test/valueObjectTest.js
+++ b/test/valueObjectTest.js
@@ -14,12 +14,27 @@ describe('ValueObject', () => {
     })
 
     it('defines types with property metadata', () => {
-      const Currency = ValueObject.define({
-        code: { type: 'string', description: 'the country code', flavour: 'spicy' }
+      const Thing = ValueObject.define({
+        foo: {
+          type: 'string',
+          description: 'the foo',
+          flavour: 'spicy',
+          spicy: true,
+          yummy: false
+        },
+        bar: {
+          type: 'string',
+          description: 'the bar',
+          flavour: 'sweet'
+        }
       })
       assert.deepEqual(
-        { description: 'the country code', flavour: 'spicy' },
-        Currency.schema.propertyTypes.code.metadata
+        { description: 'the foo', flavour: 'spicy', spicy: true, yummy: false },
+        Thing.schema.propertyTypes.foo.metadata
+      )
+      assert.deepEqual(
+        { description: 'the bar', flavour: 'sweet' },
+        Thing.schema.propertyTypes.bar.metadata
       )
     })
 

--- a/test/valueObjectTest.js
+++ b/test/valueObjectTest.js
@@ -13,6 +13,16 @@ describe('ValueObject', () => {
       assert.equal('GBP', gbp.code)
     })
 
+    it('defines types with property metadata', () => {
+      const Currency = ValueObject.define({
+        code: { type: 'string', description: 'the country code', flavour: 'spicy' }
+      })
+      assert.deepEqual(
+        { description: 'the country code', flavour: 'spicy' },
+        Currency.schema.propertyTypes.code.metadata
+      )
+    })
+
     it('defines types with nested anonymous types', () => {
       const Money = ValueObject.define({ amount: 'number', currency: { code: 'string' } })
       const allowance = new Money({ amount: 123, currency: { code: 'GBP' } })

--- a/value-object.js
+++ b/value-object.js
@@ -19,7 +19,7 @@ ValueObject.parseSchema = function(definition) {
       }
     }
     property.metadata = metadata
-    properties[propertyName] = property
+    properties[propertyName] = new Property(property, metadata)
   }
   return properties
 }
@@ -120,6 +120,30 @@ ValueObject.disableFreeze = function() {
 }
 ValueObject.enableFreeze = function() {
   freeze = enabledFreeze
+}
+
+function Property(type, metadata) {
+  this.type = type
+  this.metadata = metadata
+  if (type.toJSON) {
+    this.toJSON = function(args) {
+      return type.toJSON(args)
+    }
+  }
+  if (type.toPlainObject) {
+    this.toPlainObject = function(args) {
+      return type.toPlainObject(args)
+    }
+  }
+}
+Property.prototype.coerce = function(value) {
+  return this.type.coerce(value)
+}
+Property.prototype.areEqual = function(x, y) {
+  return this.type.areEqual(x, y)
+}
+Property.prototype.describe = function() {
+  return this.type.describe()
 }
 
 function Schema(propertyTypes) {

--- a/value-object.js
+++ b/value-object.js
@@ -7,8 +7,19 @@ function ValueObject() {
 ValueObject.parseSchema = function(definition) {
   var properties = {}
   for (var propertyName in definition) {
+    var metadata = {}
     var declared = definition[propertyName]
-    properties[propertyName] = ValueObject.findPropertyType(declared)
+    var property = ValueObject.findPropertyType(declared.type ? declared.type : declared)
+    if (declared.type) {
+      var declaredKeys = keys(declared)
+      for (var i = 0; i < declaredKeys.length; i++) {
+        if (declaredKeys[i] !== 'type') {
+          metadata[declaredKeys[i]] = declared[declaredKeys[i]]
+        }
+      }
+    }
+    property.metadata = metadata
+    properties[propertyName] = property
   }
   return properties
 }


### PR DESCRIPTION
Sometimes it's useful to associate additional data with properties. For example, it might be useful to generate documentation for value types by adding a `description` to each property.

This change allows arbitrary data to be associated with each property. Properties can be defined in the following "extended" format:

```js
class Man extends ValueObject.define({
   mood: {
      type: 'string',
      description: 'his state of mind or feelings',
      mandatory: true
   }
})
```

...which exposes every key except "type" as "metadata" on each property. So we can use reflection later to discover this configuration:

```js
Man.schema.propertyTypes.mood.metadata
// -> { description: 'his state of mind or feelings', mandatory: true }
```
