### PR TITLE
Don't use toJSON() in toPlainObject()

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,14 +8,17 @@
     "eslint": "eslint src test",
     "mocha": "mocha",
     "karma": "karma start --browsers Firefox,Chrome --single-run",
-    "coverage":
-      "node --harmony ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- test"
+    "coverage": "node --harmony ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- test"
   },
   "repository": {
     "type": "git",
     "url": "git://github.com/cucumber-ltd/value-object.js.git"
   },
-  "keywords": ["value", "object", "struct"],
+  "keywords": [
+    "value",
+    "object",
+    "struct"
+  ],
   "author": "Cucumber Limited <cukes@googlegroups.com>",
   "license": "MIT",
   "bugs": {
@@ -44,5 +47,10 @@
     "prettier": "^1.12.1",
     "watchify": "^3.10.0"
   },
-  "files": ["*"]
+  "files": [
+    "*"
+  ],
+  "dependencies": {
+    "clone": "^2.1.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@babel/preset-env": "^7.0.0-beta.40",
     "benchmark": "^2.1.4",
     "browserify": "^16.1.0",
+    "clone": "^2.1.1",
     "es6-error": "^4.1.1",
     "eslint": "^4.19.1",
     "eslint-config-eslint": "^4.0.0",
@@ -49,8 +50,5 @@
   },
   "files": [
     "*"
-  ],
-  "dependencies": {
-    "clone": "^2.1.1"
-  }
+  ]
 }

--- a/test/serializeTest.js
+++ b/test/serializeTest.js
@@ -302,14 +302,18 @@ describe('#toPlainObject()', () => {
       y2: [A],
       y3: [{z3: A}],
       y4: [{z4: [A]}],
-      y5: {z5: A}
+      y5: {z5: A},
+      y6: {z6: Date}
     }) {}
+    const y1 = new A('p1')
+    const date = new Date()
     const x = new X({
-      y1: new A('p1'),
+      y1,
       y2: [new A('p2')],
       y3: [{z3: new A('p3')}],
       y4: [{z4: [new A('p4')]}],
-      y5: {z5: new A('p5')}
+      y5: {z5: new A('p5')},
+      y6: {z6: date}
     })
     const plain = x.toPlainObject()
     assert.deepEqual(plain, {
@@ -317,7 +321,10 @@ describe('#toPlainObject()', () => {
       y2: [{p: 'p2'}],
       y3: [{z3: {p: 'p3'}}],
       y4: [{z4: [{p: 'p4'}]}],
-      y5: {z5: {p: 'p5'}}
+      y5: {z5: {p: 'p5'}},
+      y6: {z6: date}
     })
+    assert.notStrictEqual(plain.y1, y1)
+    assert.notStrictEqual(plain.y6.z6, date)
   })
 })

--- a/test/serializeTest.js
+++ b/test/serializeTest.js
@@ -2,6 +2,7 @@
 'use strict'
 
 const assert = require('assert')
+const clone = require('clone')
 const assertThrows = require('./assertThrows')
 const ValueObject = require('..')
 
@@ -261,7 +262,7 @@ describe('#toPlainObject()', () => {
     assert.strictEqual(x.y[0], 'yeah')
   })
 
-  it.only('does not call the constructor when fromJSON returns an instance of the constructor', () => {
+  it('does not call the constructor when fromJSON returns an instance of the constructor', () => {
     let calls = 0
     function LocalDate(parts) {
       this.parts = parts
@@ -288,7 +289,7 @@ describe('#toPlainObject()', () => {
     assert.equal(calls, 2)
   })
 
-  it('leaves object values intact (does not attemtp to serialize them)', function() {
+  it('can leave object values intact (does not attemtp to serialize them)', function() {
     class A {
       constructor (p) {
         this.p = p
@@ -297,34 +298,69 @@ describe('#toPlainObject()', () => {
         return 'Aaa'
       }
     }
+    class Y extends ValueObject.define({
+      o: A
+    }) {}
     class X extends ValueObject.define({
       y1: A,
       y2: [A],
       y3: [{z3: A}],
       y4: [{z4: [A]}],
       y5: {z5: A},
-      y6: {z6: Date}
+      y6: {z6: Date},
+      y7: Array,
+      y8: Array,
+      y9: Y,
+      y10: [Y]
     }) {}
     const y1 = new A('p1')
     const date = new Date()
+    const vo = new Y({o: y1})
     const x = new X({
       y1,
-      y2: [new A('p2')],
+      y2: [y1],
       y3: [{z3: new A('p3')}],
       y4: [{z4: [new A('p4')]}],
       y5: {z5: new A('p5')},
-      y6: {z6: date}
+      y6: {z6: date},
+      y7: [y1],
+      y8: [vo],
+      y9: vo,
+      y10: [vo],
     })
-    const plain = x.toPlainObject()
+    const plain = x.toPlainObject(clone)
     assert.deepEqual(plain, {
       y1: {p: 'p1'},
-      y2: [{p: 'p2'}],
+      y2: [{p: 'p1'}],
       y3: [{z3: {p: 'p3'}}],
       y4: [{z4: [{p: 'p4'}]}],
       y5: {z5: {p: 'p5'}},
-      y6: {z6: date}
+      y6: {z6: date},
+      y7: [{p: 'p1'}],
+      y8: [{o: {p: 'p1'}}],
+      y9: {o: {p: 'p1'}},
+      y10: [{o: {p: 'p1'}}]
     })
+
+    assert.deepEqual(plain.y1, y1)
     assert.notStrictEqual(plain.y1, y1)
+
+    assert.deepEqual(plain.y2[0], y1)
+    assert.notStrictEqual(plain.y2[0], y1)
+
+    assert.deepEqual(plain.y6.z6, date)
     assert.notStrictEqual(plain.y6.z6, date)
+
+    assert.deepEqual(plain.y7[0], y1)
+    assert.notStrictEqual(plain.y7[0], y1)
+
+    assert.deepEqual(plain.y8[0], vo)
+    assert.notStrictEqual(plain.y8[0], vo)
+
+    assert.deepEqual(plain.y9, vo)
+    assert.notStrictEqual(plain.y9, vo)
+
+    assert.deepEqual(plain.y10[0], vo)
+    assert.notStrictEqual(plain.y10[0], vo)
   })
 })

--- a/test/serializeTest.js
+++ b/test/serializeTest.js
@@ -261,7 +261,7 @@ describe('#toPlainObject()', () => {
     assert.strictEqual(x.y[0], 'yeah')
   })
 
-  it('does not call the constructor when fromJSON returns an instance of the constructor', () => {
+  it.only('does not call the constructor when fromJSON returns an instance of the constructor', () => {
     let calls = 0
     function LocalDate(parts) {
       this.parts = parts
@@ -286,5 +286,38 @@ describe('#toPlainObject()', () => {
     var rehydratedBooking = new Booking(plainBooking)
     assert(rehydratedBooking.arrival.date instanceof LocalDate)
     assert.equal(calls, 2)
+  })
+
+  it('leaves object values intact (does not attemtp to serialize them)', function() {
+    class A {
+      constructor (p) {
+        this.p = p
+      }
+      toJSON() {
+        return 'Aaa'
+      }
+    }
+    class X extends ValueObject.define({
+      y1: A,
+      y2: [A],
+      y3: [{z3: A}],
+      y4: [{z4: [A]}],
+      y5: {z5: A}
+    }) {}
+    const x = new X({
+      y1: new A('p1'),
+      y2: [new A('p2')],
+      y3: [{z3: new A('p3')}],
+      y4: [{z4: [new A('p4')]}],
+      y5: {z5: new A('p5')}
+    })
+    const plain = x.toPlainObject()
+    assert.deepEqual(plain, {
+      y1: {p: 'p1'},
+      y2: [{p: 'p2'}],
+      y3: [{z3: {p: 'p3'}}],
+      y4: [{z4: [{p: 'p4'}]}],
+      y5: {z5: {p: 'p5'}}
+    })
   })
 })

--- a/value-object.js
+++ b/value-object.js
@@ -317,7 +317,7 @@ Schema.prototype.toPlainObject = function(instance) {
       object[propertyName] =
         typeof property.toPlainObject === 'function'
           ? property.toPlainObject(instance[propertyName])
-          : JSON.parse(JSON.stringify(instance[propertyName]))
+          : instance[propertyName]
     }
   }
   return object
@@ -484,7 +484,7 @@ ConstructorConstraint.prototype.toPlainObject = function(instance) {
   if (instance === null) return null
   return typeof instance.toPlainObject === 'function'
     ? instance.toPlainObject()
-    : JSON.parse(JSON.stringify(instance))
+    : instance
 }
 
 function DateConstraint() {}

--- a/value-object.js
+++ b/value-object.js
@@ -1,3 +1,5 @@
+const clone = require('clone')
+
 function ValueObject() {
   var failedAssignment = this.constructor.schema.assignProperties(this, arguments)
   if (failedAssignment) {
@@ -317,7 +319,7 @@ Schema.prototype.toPlainObject = function(instance) {
       object[propertyName] =
         typeof property.toPlainObject === 'function'
           ? property.toPlainObject(instance[propertyName])
-          : instance[propertyName]
+          : clone(instance[propertyName])
     }
   }
   return object
@@ -484,7 +486,7 @@ ConstructorConstraint.prototype.toPlainObject = function(instance) {
   if (instance === null) return null
   return typeof instance.toPlainObject === 'function'
     ? instance.toPlainObject()
-    : instance
+    : clone(instance)
 }
 
 function DateConstraint() {}


### PR DESCRIPTION
Because if an object value implements toJSON then the result of
toPlainObject() is going to have toJSONified value as opposed to the
underlying object. This is unexpected as all we really want from
toPlainObject() is to get rid of __type__ properties.