### PR TITLE
Separate property type and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,11 +301,10 @@ properties and arbitrary metadata associated with each property:
 ```js
 class Product extends ValueObject.define({
   name: 'string',
-  stockLevel: {
-    type: 'number',
+  stockLevel: ValueObject.property('number', {
     default: 0,
     description: 'units in stock'
-  }
+  })
 }) {}
 
 > Product.schema.properties.stockLevel

--- a/test/defineTest.js
+++ b/test/defineTest.js
@@ -14,18 +14,16 @@ describe('.define(definition)', () => {
 
   it('defines types with property metadata', () => {
     const Thing = ValueObject.define({
-      foo: {
-        type: 'string',
+      foo: ValueObject.property('string', {
         description: 'the foo',
         flavour: 'spicy',
         spicy: true,
         yummy: false
-      },
-      bar: {
-        type: 'string',
+      }),
+      bar: ValueObject.property('string', {
         description: 'the bar',
         flavour: 'sweet'
-      }
+      })
     })
     assert.deepEqual(
       { description: 'the foo', flavour: 'spicy', spicy: true, yummy: false },
@@ -38,7 +36,7 @@ describe('.define(definition)', () => {
   })
 
   it('defines types with typed arrays with property metadata', () => {
-    const Foo = ValueObject.define({ zzz: { type: 'string', blah: 'yeah' } })
+    const Foo = ValueObject.define({ zzz: ValueObject.property('string', { blah: 'yeah' }) })
     const Thing = ValueObject.define({
       foo: [Foo]
     })
@@ -50,7 +48,7 @@ describe('.define(definition)', () => {
 
   it('defines types with typed arrays with inline types with property metadata', () => {
     const Thing = ValueObject.define({
-      foo: [{ zzz: { type: 'string', blah: 'yeah' } }]
+      foo: [{ zzz: ValueObject.property('string', { blah: 'yeah' }) }]
     })
     assert.deepEqual(
       { blah: 'yeah' },

--- a/value-object.js
+++ b/value-object.js
@@ -8,23 +8,19 @@ function ValueObject() {
     throw new ValueObjectError(failedAssignment)
   }
 }
+ValueObject.property = function(declaration, metadata) {
+  var parsedDeclaration = this.parseDeclaration(declaration)
+  var constraintFactory = ValueObject.constraintFactoryForDeclaration(parsedDeclaration)
+  var constraint = constraintFactory()
+  return new Property(constraint, metadata, parsedDeclaration.optional)
+}
 ValueObject.parseSchema = function(definition) {
   var properties = {}
   for (var propertyName in definition) {
-    var metadata = {}
-    var declaration = definition[propertyName]
-    if (declaration.type) {
-      var declaredKeys = keys(declaration)
-      for (var i = 0; i < declaredKeys.length; i++) {
-        if (declaredKeys[i] !== 'type') {
-          metadata[declaredKeys[i]] = declaration[declaredKeys[i]]
-        }
-      }
-    }
-    var parsedDeclaration = this.parseDeclaration(declaration)
-    var constraintFactory = ValueObject.constraintFactoryForDeclaration(parsedDeclaration)
-    var constraint = constraintFactory()
-    properties[propertyName] = new Property(constraint, metadata, parsedDeclaration.optional)
+    properties[propertyName] =
+      definition[propertyName] instanceof Property
+        ? definition[propertyName]
+        : ValueObject.property(definition[propertyName], {})
   }
   return properties
 }
@@ -439,7 +435,9 @@ UntypedArrayConstraint.prototype.toPlainObject = function(instance, cloneFn) {
   return instance === null
     ? null
     : instance.map(function(element) {
-        return typeof element.toPlainObject === 'function' ? element.toPlainObject(cloneFn) : cloneFn(element)
+        return typeof element.toPlainObject === 'function'
+          ? element.toPlainObject(cloneFn)
+          : cloneFn(element)
       })
 }
 


### PR DESCRIPTION
We recently introduced a way of associating arbitrary metadata with properties, like:

```js
ValueObject.define({
  someProperty: {
    type: 'string',
    meta1: true,
    meta2: { what: 'ever' }
  }
})
```

...however this makes it impossible to define any inline types with a property called "type", which unfortunately is a fairly common property name.

To avoid this issue, this change introduces a new method called `property`, which defines a property _with metadata_:

 ```js
ValueObject.define({
   someProperty: ValueObject.property('string', {
     meta1: true,
     meta2: { what: 'ever' }
   })
})
```