### PR TITLE
From json can return null

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "value-object",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "value-object.js - simple value objects",
   "main": "value-object.js",
   "scripts": {

--- a/test/serializeTest.js
+++ b/test/serializeTest.js
@@ -76,6 +76,19 @@ describe('ValueObject.fromJSON', () => {
 
     assert.equal(newSubscription.state.constructor, Active)
   })
+
+  it('can return null', () => {
+    class Bar extends ValueObject.define({}) {
+      static fromJSON() {
+        return null
+      }
+    }
+    class Foo extends ValueObject.define({
+      prop: Bar
+    }) {}
+    const foo = new Foo({ prop: '' })
+    assert.strictEqual(foo.prop, null)
+  })
 })
 
 describe('ValueObject.deserializeForNamespaces([ { TypeA }, { TypeB } ])', () => {
@@ -311,7 +324,7 @@ describe('#toPlainObject()', () => {
     assert.equal(calls, 2)
   })
 
-  it('can leave object values intact (does not attemtp to serialize them)', function() {
+  it('can leave object values intact (does not attempt to serialize them)', function() {
     class A {
       constructor(p) {
         this.p = p

--- a/value-object.js
+++ b/value-object.js
@@ -451,9 +451,9 @@ ConstructorConstraint.prototype.coerce = function(value) {
     var Constructor = this.ctor
     if (!(value instanceof Constructor)) {
       if (typeof Constructor.fromJSON === 'function') {
-        var properties = Constructor.fromJSON(value)
-        if (properties instanceof Constructor) return { value: properties }
-        return { value: new Constructor(properties) }
+        var fromJSON = Constructor.fromJSON(value)
+        if (fromJSON === null || fromJSON instanceof Constructor) return { value: fromJSON }
+        return { value: new Constructor(fromJSON) }
       }
       if (value && value.constructor === Object) {
         return { value: new Constructor(value) }


### PR DESCRIPTION
Allow `ValueObjectSubclass.fromJSON()` to return `null`