### PR TITLE
Rethrow nested constructor errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,14 +8,17 @@
     "eslint": "eslint src test",
     "mocha": "mocha",
     "karma": "karma start --browsers Firefox,Chrome --single-run",
-    "coverage":
-      "node --harmony ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- test"
+    "coverage": "node --harmony ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- test"
   },
   "repository": {
     "type": "git",
     "url": "git://github.com/cucumber-ltd/value-object.js.git"
   },
-  "keywords": ["value", "object", "struct"],
+  "keywords": [
+    "value",
+    "object",
+    "struct"
+  ],
   "author": "Cucumber Limited <cukes@googlegroups.com>",
   "license": "MIT",
   "bugs": {
@@ -29,10 +32,10 @@
     "browserify": "^16.1.0",
     "clone": "^2.1.1",
     "es6-error": "^4.1.1",
-    "eslint": "^4.19.1",
-    "eslint-config-eslint": "^4.0.0",
+    "eslint": "^5.9.0",
+    "eslint-config-eslint": "^5.0.1",
     "istanbul": "1.0.0-alpha.2",
-    "karma": "^2.0.0",
+    "karma": "^3.1.1",
     "karma-babel-preprocessor": "^8.0.0-beta.0",
     "karma-browserify": "^5.2.0",
     "karma-chrome-launcher": "^2.2.0",
@@ -41,9 +44,11 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "microtime": "^2.1.7",
-    "mocha": "^3.4.2",
+    "mocha": "^5.2.0",
     "prettier": "^1.12.1",
     "watchify": "^3.10.0"
   },
-  "files": ["*"]
+  "files": [
+    "*"
+  ]
 }

--- a/test/assertThrows.js
+++ b/test/assertThrows.js
@@ -9,7 +9,7 @@ function assertThrows(fn, message, expose = () => {}) {
   } catch (err) {
     assert(typeof err !== 'undefined', 'threw undefined!')
     if (message instanceof RegExp) {
-      assert(err.message.match(message))
+      assert(err.message.match(message), 'Expected ' + message + ' to match:\n' + err.message)
     } else {
       assert.equal(err.message, message)
     }

--- a/test/serializeTest.js
+++ b/test/serializeTest.js
@@ -238,6 +238,20 @@ describe('#toPlainObject()', () => {
     assert.equal(JSON.stringify(y.toPlainObject()), '{"b":[{"a":1},null],"c":[{"d":null}]}')
   })
 
+  it('calls toPlainObject() on any objects it finds', () => {
+    class X extends ValueObject.define({ a: 'number' }) {
+      toPlainObject() {
+        return 'YO'
+      }
+    }
+    class Y extends ValueObject.define({ b: [X], c: { e: X } }) {}
+    class Z extends ValueObject.define({ d: [Y] }) {}
+
+    const z = new Z({ d: [new Y({ b: [new X({ a: 123 })], c: { e: new X({ a: 456 }) } })] })
+
+    assert.equal(JSON.stringify(z.toPlainObject()), '{"d":[{"b":["YO"],"c":{"e":"YO"}}]}')
+  })
+
   it('converts untyped array properties', () => {
     class X extends ValueObject.define({ a: Array, b: Array }) {}
 

--- a/value-object.js
+++ b/value-object.js
@@ -465,7 +465,9 @@ ConstructorConstraint.prototype.coerce = function(value) {
     return { value: value }
   } catch (e) {
     if (e.failure) return e
-    throw e
+    return {
+      failure: Constructor.name + ' could not be instantiated:\n' + e.stack + '\n'
+    }
   }
 }
 ConstructorConstraint.prototype.areEqual = function(a, b) {
@@ -714,7 +716,10 @@ function describeInvalidPropertyValues(invalidPropertyValues, indent) {
       indent +
       invalidPropertyValues.propertyName +
       ' is invalid:\n' +
-      describeInvalidPropertyValues(invalidPropertyValues.failure, indent + '  ')
+      describeInvalidPropertyValues(
+        indentLines(invalidPropertyValues.failure, indent),
+        indent + '  '
+      )
     )
   }
 
@@ -739,6 +744,16 @@ function describeInvalidPropertyValues(invalidPropertyValues, indent) {
           })
           .join('\n')
     : typeExplanation
+}
+
+function indentLines(string, indent) {
+  if (!string.split) return string
+  var lines = string.split('\n')
+  return lines
+    .map(function(line, i) {
+      return i === 0 ? line : indent + '  ' + line
+    })
+    .join('\n')
 }
 
 function disabledFreeze() {}


### PR DESCRIPTION
When a property is declared with a constructor constraint, e.g.

```js
var MyValue = Value.define({ x: SomeConstructor, y: SomeConstructor })
```

...and `SomeConstructor` throws an error, then instantiating `MyValue` like this:

```js
new MyValue({ x: {}, y: {})
```

...does not explain which property caused the error. This can be painful when instantiating a large object. And it's inconsistent with other failures.

Therefore, when `SomeConstructor` throws, this change makes ValueObject report the error like it would any other coercion failure, only with a stack trace, e.g.

```
MyValue was constructed with invalid property values:
  x was invalid:
    SomeConstructor could not be instantiated:
       [...stack trace...]
  y was invalid:
    SomeConstructor could not be instantiated:
       [...stack trace...]
```